### PR TITLE
dependency documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ and (2) creating figures from the resultant data frames.
 
 Dependencies
 ------------
-This package relies on the following files which may not be present in a vanilla analysis environment:
-texi2dvi -- ptmr8t.tfm -- inconsolata.sty
+This package relies on the following files which may not be present in a vanilla analysis environment:  
+texi2dvi  
+ptmr8t.tfm  
+inconsolata.sty
 
 On Debian systems:
 


### PR DESCRIPTION
a vanilla debian-based analysis environment is unlikely to have these dependencies for compiliation.
Compliation aside, report generation will not work properly without latex (probably texlive) and pdf generation definitely relies on the texinfo package
